### PR TITLE
update x402 contract addresses

### DIFF
--- a/docs/finance-solutions/x402/network-and-contracts.mdx
+++ b/docs/finance-solutions/x402/network-and-contracts.mdx
@@ -17,8 +17,8 @@ or real funds.
 
 | Contract | Address |
 |---|---|
-| Merces Contract | `0x7F73402cB6AF7Ffa446e2D463701e3eA89C95f8f` |
-| Confidential USDC token | `0x6AA4dd47444154A1E4424D08622EF6e96bf66de6` |
+| Merces Contract | `0x2A07183Ec9cFFCED639C9Cb33BE106FD81d59E16` |
+| Confidential USDC token | `0x4Ee80fFA1332525A8Cd100E1edf72Fe066f01c10` |
 
 Contract source code is available in the
 [merces1-x402 GitHub repository](https://github.com/TaceoLabs/merces1-x402).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only update to testnet contract addresses; no application or on-chain code changes.
> 
> **Overview**
> Updates the **Deployed contracts** table in `network-and-contracts.mdx` so Base Sepolia testnet docs match the current x402 deployment.
> 
> **Merces Contract** is now `0x2A07183Ec9cFFCED639C9Cb33BE106FD81d59E16` (was `0x7F73402cB6AF7Ffa446e2D463701e3eA89C95f8f`). **Confidential USDC token** is now `0x4Ee80fFA1332525A8Cd100E1edf72Fe066f01c10` (was `0x6AA4dd47444154A1E4424D08622EF6e96bf66de6`). No other sections or files change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dceca4ed25f40a38500afcbb7f422882a9bdb459. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->