### PR TITLE
chore: redirect for moved page

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -52,12 +52,16 @@ const config: Config = {
           { from: "/docs/design/known-issues", to: "/docs/" },
           { from: "/docs/design/roadmap", to: "/docs/" },
           { from: "/docs/contact", to: "/docs/" },
+          {
+            from: "/docs/finance-solutions/x402/",
+            to: "/docs/finance-solutions/x402/introduction/",
+          },
         ],
       },
     ],
   ],
 
-  themes: ['@docusaurus/theme-mermaid'],
+  themes: ["@docusaurus/theme-mermaid"],
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
@@ -189,13 +193,13 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
-      additionalLanguages: ['solidity'],
+      additionalLanguages: ["solidity"],
     },
     zoom: {
-      selector: '.markdown img, .docusaurus-mermaid-container svg',
+      selector: ".markdown img, .docusaurus-mermaid-container svg",
       background: {
-        light: 'rgb(255, 255, 255)',
-        dark: 'rgb(50, 50, 50)',
+        light: "rgb(255, 255, 255)",
+        dark: "rgb(50, 50, 50)",
       },
     },
   } satisfies Preset.ThemeConfig,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-site redirect and formatting-only config tweaks; no application or security impact.
> 
> **Overview**
> Adds a **client redirect** so `/docs/finance-solutions/x402/` sends visitors to `/docs/finance-solutions/x402/introduction/`, matching the x402 docs landing page after the section was moved/restructured.
> 
> Also normalizes string quotes in `docusaurus.config.ts` (themes, prism, zoom) with no behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5722a97a45b216a2d310425d64c05ab9e5c2f48c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->